### PR TITLE
PURRSOFT-140 Add Shift Controller API Endpoint for general information for shifts on a certain date

### DIFF
--- a/PurrSoft/PurrSoft.Api/Controllers/ShiftController.cs
+++ b/PurrSoft/PurrSoft.Api/Controllers/ShiftController.cs
@@ -7,6 +7,7 @@ using PurrSoft.Application.Common;
 using PurrSoft.Application.Models;
 using PurrSoft.Application.Queries.ShiftQueries;
 using PurrSoft.Application.QueryOverviews;
+using PurrSoft.Application.QueryResponses;
 using System.Net;
 
 namespace PurrSoft.Api.Controllers;
@@ -92,6 +93,25 @@ public class ShiftController : BaseController
 			CommandResponse commandResponse = await Mediator.Send(new DeleteShiftCommand { Id = id }, new CancellationToken());
 
 			return commandResponse.IsValid ? Ok(commandResponse) : BadRequest(commandResponse);
+		}
+		catch (ValidationException ex)
+		{
+			return BadRequest(new CommandResponse(ex.Errors.ToList()));
+		}
+	}
+
+	[HttpGet("GetCountByDate")]
+	[Authorize(AuthenticationSchemes = "Bearer", Roles = "Manager, Volunteer, Admin")]
+	[ProducesResponseType(typeof(int), (int)HttpStatusCode.OK)]
+	[ProducesResponseType((int)HttpStatusCode.BadRequest)]
+	public async Task<IActionResult> GetShiftCountByDate([FromQuery] GetShiftCountQuery getShiftCountQuery)
+	{
+		try
+		{
+			ShiftCountByDateResponse shiftCountByDateResponse =
+				await Mediator.Send(getShiftCountQuery, new CancellationToken());
+
+			return Ok(shiftCountByDateResponse);
 		}
 		catch (ValidationException ex)
 		{

--- a/PurrSoft/PurrSoft.Api/Controllers/ShiftController.cs
+++ b/PurrSoft/PurrSoft.Api/Controllers/ShiftController.cs
@@ -102,7 +102,7 @@ public class ShiftController : BaseController
 
 	[HttpGet("GetCountByDate")]
 	[Authorize(AuthenticationSchemes = "Bearer", Roles = "Manager, Volunteer, Admin")]
-	[ProducesResponseType(typeof(int), (int)HttpStatusCode.OK)]
+	[ProducesResponseType(typeof(ShiftCountByDateResponse), (int)HttpStatusCode.OK)]
 	[ProducesResponseType((int)HttpStatusCode.BadRequest)]
 	public async Task<IActionResult> GetShiftCountByDate([FromQuery] GetShiftCountQuery getShiftCountQuery)
 	{

--- a/PurrSoft/PurrSoft.Application/Queries/ShiftQueries/ShiftQueries.cs
+++ b/PurrSoft/PurrSoft.Application/Queries/ShiftQueries/ShiftQueries.cs
@@ -1,6 +1,7 @@
 ﻿using PurrSoft.Application.Common;
 using PurrSoft.Application.Models;
 using PurrSoft.Application.QueryOverviews;
+using PurrSoft.Application.QueryResponses;
 
 namespace PurrSoft.Application.Queries.ShiftQueries;
 
@@ -18,4 +19,9 @@ public class GetFilteredShiftsQueries : BaseRequest<CollectionResponse<ShiftOver
 public class GetShiftQuery : BaseRequest<ShiftDto?>
 {
 	public Guid Id { get; set; }
+}
+
+public class GetShiftCountQuery : BaseRequest<ShiftCountByDateResponse>
+{
+	public DateTime Date { get; set; }
 }

--- a/PurrSoft/PurrSoft.Application/Queries/ShiftQueries/ShiftQueryHandler.cs
+++ b/PurrSoft/PurrSoft.Application/Queries/ShiftQueries/ShiftQueryHandler.cs
@@ -5,15 +5,18 @@ using PurrSoft.Application.Common;
 using PurrSoft.Application.Models;
 using PurrSoft.Application.QueryOverviews;
 using PurrSoft.Application.QueryOverviews.Mappers;
+using PurrSoft.Application.QueryResponses;
 using PurrSoft.Common.Helpful;
 using PurrSoft.Domain.Entities;
+using PurrSoft.Domain.Entities.Enums;
 using PurrSoft.Domain.Repositories;
 
 namespace PurrSoft.Application.Queries.ShiftQueries;
 
 public class ShiftQueryHandler(IRepository<Shift> shiftRepository, ILogRepository<Shift> logRepository) :
 	IRequestHandler<GetFilteredShiftsQueries, CollectionResponse<ShiftOverview>>,
-	IRequestHandler<GetShiftQuery, ShiftDto?>
+	IRequestHandler<GetShiftQuery, ShiftDto?>,
+	IRequestHandler<GetShiftCountQuery, ShiftCountByDateResponse>
 {
 	public async Task<CollectionResponse<ShiftOverview>> Handle(GetFilteredShiftsQueries request, CancellationToken cancellationToken)
 	{
@@ -46,5 +49,19 @@ public class ShiftQueryHandler(IRepository<Shift> shiftRepository, ILogRepositor
 			.FirstOrDefaultAsync(cancellationToken);
 
 		return shiftDto;
+	}
+
+	public async Task<ShiftCountByDateResponse> Handle(GetShiftCountQuery request, CancellationToken cancellationToken)
+	{
+		var shifts = await shiftRepository.Query(s => s.Start.Date == request.Date.Date).ToListAsync(cancellationToken);	
+
+		ShiftCountByDateResponse shiftCountByDateResponse = new()
+		{
+			TotalShiftCount = shifts.Count,
+			DayShiftsCount = shifts.Count(s => s.ShiftType == ShiftType.Day),
+			NightShiftsCount = shifts.Count(s => s.ShiftType == ShiftType.Night)
+		};
+
+		return shiftCountByDateResponse;
 	}
 }

--- a/PurrSoft/PurrSoft.Application/QueryResponses/ShiftCountByDateResponse.cs
+++ b/PurrSoft/PurrSoft.Application/QueryResponses/ShiftCountByDateResponse.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PurrSoft.Application.QueryResponses;
+
+public class ShiftCountByDateResponse
+{
+	public int TotalShiftCount { get; set; }
+	public int DayShiftsCount { get; set; }
+	public int NightShiftsCount { get; set; }
+}


### PR DESCRIPTION
- added new `/api/Shift/GetCountByDate/` endpoint to get shifts total, day and night count by a specfic date
- request: `DateTime query parameter`
- response structure:
```
{
  "totalShiftCount": 0,
  "dayShiftsCount": 0,
  "nightShiftsCount": 0
}
```